### PR TITLE
feat: Add optional support for Android Wear and Android TV

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" >
 
+    <uses-feature android:name="android.hardware.type.watch" android:required="false" />
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:banner="@drawable/app_banner"
         tools:ignore="AllowBackup">
         <activity
             android:name=".MainActivity"
@@ -11,8 +16,11 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" >
 
-    <uses-feature android:name="android.hardware.type.watch" android:required="false" />
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 

--- a/app/src/main/res/drawable/app_banner.xml
+++ b/app/src/main/res/drawable/app_banner.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/black" />
+    <size
+        android:width="320dp"
+        android:height="180dp" />
+</shape>


### PR DESCRIPTION
Adds the necessary manifest declarations and a placeholder TV banner to enable the app to be optionally installed and run on Android Wear (Wear OS) and Android TV devices.

- Declared `android.hardware.type.watch` and `android.software.leanback` features as not required.
- Added `android.hardware.touchscreen` as not required.
- Included a LEANBACK_LAUNCHER intent filter for the main activity.
- Added a placeholder app_banner.xml for TV.